### PR TITLE
Fix bug: avoid updating orderform when is not logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Issue with orderform. Avoid Creating new orderform when user is not logged. A new orderForm deletes cart items when user is not logged
+
 ## [1.0.1] - 2022-10-14
 
 ### Fix

--- a/react/eventHandlers/onEmailChanged.ts
+++ b/react/eventHandlers/onEmailChanged.ts
@@ -12,6 +12,6 @@ export const onEmailChanged = (old: OrderForm, updated: OrderForm) => {
     eventName: 'order-form-email-updated',
     eventObject: { email: newEmail, orderFormId: updated.orderFormId },
     // triggered: oldEmail !== newEmail,
-    triggered: newEmail !== null,
+    triggered: newEmail !== null && newEmail !== undefined,
   } as OrderFormEvent<{ email: string; orderFormId: string }>
 }


### PR DESCRIPTION
**What problem is this solving?**

A new orderform is requested if an user is not logged. It delete all items and data on cart. 

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

https://www.loom.com/share/b1070306c4d743c3bbbad8ec2d700ccc?sid=d98d270e-caab-4342-8d3c-394fc5e47ab2
